### PR TITLE
Server: show usage instead of crash when no command-line arguments are given

### DIFF
--- a/tf/server/start.py
+++ b/tf/server/start.py
@@ -128,6 +128,9 @@ def getKill():
 
 
 def main():
+  if len(sys.argv) < 2:
+    print('Usage: {} [-h] [-d] [-k] DATASOURCE'.format(sys.argv[0]))
+    return
   if sys.argv[1] in {'--help', '-help', '-h', '?', '-?'}:
     print(HELP)
 


### PR DESCRIPTION
Previously, running `text-fabric` would cause an index out of range error.